### PR TITLE
Fix missing Notes link in challenges sidebar

### DIFF
--- a/courses/dashboard/challenges.html
+++ b/courses/dashboard/challenges.html
@@ -118,9 +118,15 @@
                 <span class="nav-text">Achievements</span>
               </a>
             </li>
+            <li class="nav-item">
+              <a href="notes.html" class="nav-link">
+                <span class="nav-icon">📝</span>
+                <span class="nav-text">Notes</span>
+              </a>
+            </li>
           </ul>
         </div>
-        
+
         <div class="nav-section">
           <span class="nav-section-title">Community</span>
           <ul class="nav-list">


### PR DESCRIPTION
## Summary
- Added the missing Notes nav item to the Learning section in `challenges.html`
- This was the only dashboard page missing the Notes link in its sidebar

## Test plan
- [ ] Open challenges.html and verify Notes appears in the Learning section between Achievements and Community
- [ ] Click the Notes link and confirm it navigates to notes.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)